### PR TITLE
use pkg_search_module to find minizip-ng or minizip

### DIFF
--- a/CMake/DolphinLibraryTools.cmake
+++ b/CMake/DolphinLibraryTools.cmake
@@ -79,7 +79,7 @@ function(dolphin_find_optional_system_library_pkgconfig library search alias bun
   dolphin_optional_system_library(${library})
   string(TOUPPER ${library} upperlib)
   if(RESOLVED_USE_SYSTEM_${upperlib})
-    pkg_check_modules(${library} ${search} ${ARGN} IMPORTED_TARGET)
+    pkg_search_module(${library} ${search} ${ARGN} IMPORTED_TARGET)
     if((NOT ${library}_FOUND) AND (NOT ${RESOLVED_USE_SYSTEM_${upperlib}} STREQUAL "AUTO"))
       message(FATAL_ERROR "No system ${library} was found.  Please install it or set USE_SYSTEM_${upperlib} to AUTO or OFF.")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,8 +674,9 @@ dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Ex
 
 dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
 
-# TODO: Some distributions might call this package "minizip" without the "-ng" suffix.
-dolphin_find_optional_system_library_pkgconfig(MINIZIP minizip-ng>=4.0.4 minizip::minizip Externals/minizip-ng)
+dolphin_find_optional_system_library_pkgconfig(MINIZIP
+  "minizip-ng>=4.0.4;minizip>=4.0.4" minizip::minizip Externals/minizip-ng
+)
 
 dolphin_find_optional_system_library(LZO Externals/LZO)
 


### PR DESCRIPTION
Tested on OpenBSD 7.5 only.

Edit: sorry, force-pushed because I forgot to remove the TODO comment.